### PR TITLE
URL Cleanup

### DIFF
--- a/org.grails.ide.eclipse.maven.test/testProjects/ggts-maven-test/pom.xml
+++ b/org.grails.ide.eclipse.maven.test/testProjects/ggts-maven-test/pom.xml
@@ -162,12 +162,12 @@
 		<repository>
 			<id>grails</id>
 			<name>grails</name>
-			<url>http://repo.grails.org/grails/core</url>
+			<url>https://repo.grails.org/grails/core</url>
 		</repository>
 		<repository>
 			<id>grails-plugins</id>
 			<name>grails-plugins</name>
-			<url>http://repo.grails.org/grails/plugins</url>
+			<url>https://repo.grails.org/grails/plugins</url>
 		</repository>
 	</repositories>
 

--- a/org.grails.ide.eclipse.maven.test/testProjects/ggts-maven-test/src/main/webapp/META-INF/maven/example/ggts-maven-test/pom.xml
+++ b/org.grails.ide.eclipse.maven.test/testProjects/ggts-maven-test/src/main/webapp/META-INF/maven/example/ggts-maven-test/pom.xml
@@ -159,12 +159,12 @@
 		<repository>
 			<id>grails</id>
 			<name>grails</name>
-			<url>http://repo.grails.org/grails/core</url>
+			<url>https://repo.grails.org/grails/core</url>
 		</repository>
 		<repository>
 			<id>grails-plugins</id>
 			<name>grails-plugins</name>
-			<url>http://repo.grails.org/grails/plugins</url>
+			<url>https://repo.grails.org/grails/plugins</url>
 		</repository>
 	</repositories>
 

--- a/org.grails.ide.eclipse.site.dependencies/pom.xml
+++ b/org.grails.ide.eclipse.site.dependencies/pom.xml
@@ -17,7 +17,7 @@
      <pluginRepository>
        <id>plugins-snapshot-local</id>
        <name>plugins-snapshot-local</name>
-       <url>http://repo.spring.io/plugins-snapshot-local</url>
+       <url>https://repo.spring.io/plugins-snapshot-local</url>
        <snapshots>
          <enabled>true</enabled>
        </snapshots>
@@ -106,11 +106,11 @@
             	 <name>Grails IDE Composite Site for Eclipse 4.3</name>
             	 <target>${project.build.directory}/site/e4.3</target>
 		         <sites>
-				   <param>http://dist.springsource.com/snapshot/TOOLS/grails-ide/nightly</param>         
-		           <param>http://dist.springsource.com/snapshot/TOOLS/eclipse-integration-commons/nightly/</param>
-		           <param>http://dist.springsource.com/snapshot/TOOLS/eclipse-integration-commons/nightly/</param>
-		           <param>http://dist.springsource.org/snapshot/GRECLIPSE/e4.3/</param>
-		           <param>http://download.eclipse.org/tools/ajdt/43/milestone/</param>
+				   <param>https://dist.springsource.com/snapshot/TOOLS/grails-ide/nightly</param>         
+		           <param>https://dist.springsource.com/snapshot/TOOLS/eclipse-integration-commons/nightly/</param>
+		           <param>https://dist.springsource.com/snapshot/TOOLS/eclipse-integration-commons/nightly/</param>
+		           <param>https://dist.springsource.org/snapshot/GRECLIPSE/e4.3/</param>
+		           <param>https://download.eclipse.org/tools/ajdt/43/milestone/</param>
 		         </sites>
             </configuration>
           </execution>
@@ -120,11 +120,11 @@
             	 <name>Grails IDE Composite Site for Eclipse 4.2</name>
             	 <target>${project.build.directory}/site/e4.2</target>
 		         <sites>
-				   <param>http://dist.springsource.com/snapshot/TOOLS/grails-ide/nightly</param>         
-		           <param>http://dist.springsource.com/snapshot/TOOLS/eclipse-integration-commons/nightly/</param>
-		           <param>http://dist.springsource.com/snapshot/TOOLS/eclipse-integration-commons/nightly/</param>
-		           <param>http://dist.springsource.org/snapshot/GRECLIPSE/e4.2/</param>
-		           <param>http://download.eclipse.org/tools/ajdt/42/milestone/</param>
+				   <param>https://dist.springsource.com/snapshot/TOOLS/grails-ide/nightly</param>         
+		           <param>https://dist.springsource.com/snapshot/TOOLS/eclipse-integration-commons/nightly/</param>
+		           <param>https://dist.springsource.com/snapshot/TOOLS/eclipse-integration-commons/nightly/</param>
+		           <param>https://dist.springsource.org/snapshot/GRECLIPSE/e4.2/</param>
+		           <param>https://download.eclipse.org/tools/ajdt/42/milestone/</param>
 		         </sites>
             </configuration>
           </execution>
@@ -192,12 +192,12 @@
     <pluginRepository> 
       <id>spring-maven-release</id>
       <name>Spring Maven Release Repository</name>
-      <url>http://maven.springframework.org/release</url>
+      <url>https://maven.springframework.org/release</url>
     </pluginRepository>
     <pluginRepository>
       <id>springsource-maven-release</id>
       <name>SpringSource Maven Release Repository</name>
-      <url>http://repository.springsource.com/maven/bundles/release</url>
+      <url>https://repository.springsource.com/maven/bundles/release</url>
     </pluginRepository>
   </pluginRepositories>
 	-->

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <connection>scm:git:ssh://git.springsource.com:sts/grails-ide.git</connection>
     <developerConnection>scm:git:ssh://git.springsource.com:sts/grails-ide.git</developerConnection>
     <tag>HEAD</tag>
-    <url>http://git.springsource.com/sts/grails-ide</url>
+    <url>https://git.springsource.com/sts/grails-ide</url>
   </scm>
 
   <modules>
@@ -56,9 +56,9 @@
   <!-- Common Configuration -->
   <organization>
     <name>GoPivotal, Inc.</name>
-    <url>http://spring.io</url>
+    <url>https://spring.io</url>
   </organization>
-  <url>http://spring.io/tools</url>
+  <url>https://spring.io/tools</url>
   <inceptionYear>2007</inceptionYear>
 
   <prerequisites>
@@ -171,42 +171,42 @@
 		<repository>
 		  <id>platform</id>
 		  <layout>p2</layout>
-		  <url>http://download.eclipse.org/eclipse/updates/3.7/</url>
+		  <url>https://download.eclipse.org/eclipse/updates/3.7/</url>
 		</repository>
 <!-- 	<repository> 
 		  <id>platform201106131736</id>
 		  <layout>p2</layout>
-		  <url>http://download.eclipse.org/eclipse/updates/3.7/R-3.7-201106131736</url>
+		  <url>https://download.eclipse.org/eclipse/updates/3.7/R-3.7-201106131736</url>
 		</repository> -->
 		<repository>
 		  <id>indigo</id>
 		  <layout>p2</layout>
-		  <url>http://download.eclipse.org/releases/indigo/</url>
+		  <url>https://download.eclipse.org/releases/indigo/</url>
 		</repository>
 		<repository>
 		  <id>ajdt</id>
 		  <layout>p2</layout>
-		  <url>http://download.eclipse.org/tools/ajdt/37/milestone/</url>
+		  <url>https://download.eclipse.org/tools/ajdt/37/milestone/</url>
 		</repository>
 		<repository>
 		  <id>swtbot</id>
 		  <layout>p2</layout>
-		  <url>http://download.eclipse.org/technology/swtbot/helios/dev-build/update-site/</url>
+		  <url>https://download.eclipse.org/technology/swtbot/helios/dev-build/update-site/</url>
 		</repository>
 		<repository>
 		  <id>groovy</id>
 		  <layout>p2</layout>
-		  <url>http://dist.springsource.org/snapshot/GRECLIPSE/e3.7/</url>
+		  <url>https://dist.springsource.org/snapshot/GRECLIPSE/e3.7/</url>
 		</repository>
 		<repository>
 		  <id>linkedFolderBugPatch</id>
 		  <layout>p2</layout>
-		  <url>http://dist.springsource.com/release/TOOLS/patches/bug367669</url>
+		  <url>https://dist.springsource.com/release/TOOLS/patches/bug367669</url>
 		</repository>
 		<repository>
 		  <id>eclipse-integration-commons</id>
 		  <layout>p2</layout>
-		  <url>http://dist.springsource.com/${dist.type}/TOOLS/eclipse-integration-commons/${dist.eclipse-integration-commons-version}/e3.7/</url>
+		  <url>https://dist.springsource.com/${dist.type}/TOOLS/eclipse-integration-commons/${dist.eclipse-integration-commons-version}/e3.7/</url>
 		</repository>
 	  </repositories>
     </profile>
@@ -226,38 +226,38 @@
 		<repository>
 		  <id>platform</id>
 		  <layout>p2</layout>
-		  <url>http://download.eclipse.org/eclipse/updates/4.2/</url>
+		  <url>https://download.eclipse.org/eclipse/updates/4.2/</url>
 		</repository>
 		<!-- this does not make sense, but without this site tycho can't find the 'SWT fragment bundles' -->
 		<!-- <repository>
 			<id>indigo</id>
 			<layout>p2</layout>
-			<url>http://download.eclipse.org/releases/indigo/</url>
+			<url>https://download.eclipse.org/releases/indigo/</url>
 		</repository> -->
 		<repository>
 		  <id>juno</id>
 		  <layout>p2</layout>
-		  <url>http://download.eclipse.org/releases/juno/</url>
+		  <url>https://download.eclipse.org/releases/juno/</url>
 		</repository>
 		<repository>
 		  <id>ajdt</id>
 		  <layout>p2</layout>
-		  <url>http://download.eclipse.org/tools/ajdt/42/milestone/</url>
+		  <url>https://download.eclipse.org/tools/ajdt/42/milestone/</url>
 		</repository>
 		<repository>
 		  <id>swtbot</id>
 		  <layout>p2</layout>
-		  <url>http://download.eclipse.org/technology/swtbot/helios/dev-build/update-site/</url>
+		  <url>https://download.eclipse.org/technology/swtbot/helios/dev-build/update-site/</url>
 		</repository>
 		<repository>
 		  <id>groovy</id>
 		  <layout>p2</layout>
-		  <url>http://dist.springsource.org/snapshot/GRECLIPSE/e4.2/</url>
+		  <url>https://dist.springsource.org/snapshot/GRECLIPSE/e4.2/</url>
 		</repository>
 		<repository>
 		  <id>eclipse-integration-commons</id>
 		  <layout>p2</layout>
-		  <url>http://dist.springsource.com/${dist.type}/TOOLS/eclipse-integration-commons/${dist.eclipse-integration-commons-version}/e3.7/</url>
+		  <url>https://dist.springsource.com/${dist.type}/TOOLS/eclipse-integration-commons/${dist.eclipse-integration-commons-version}/e3.7/</url>
 		</repository>
 	  </repositories>
     </profile>
@@ -277,38 +277,38 @@
 		<repository>
 		  <id>platform</id>
 		  <layout>p2</layout>
-		  <url>http://download.eclipse.org/eclipse/updates/4.3/</url>
+		  <url>https://download.eclipse.org/eclipse/updates/4.3/</url>
 		</repository>
 		<!-- this does not make sense, but without this site tycho can't find the 'SWT fragment bundles' -->
 		<!-- <repository>
 			<id>indigo</id>
 			<layout>p2</layout>
-			<url>http://download.eclipse.org/releases/indigo/</url>
+			<url>https://download.eclipse.org/releases/indigo/</url>
 		</repository> -->
 		<repository>
 		  <id>kepler</id>
 		  <layout>p2</layout>
-		  <url>http://download.eclipse.org/releases/kepler/</url>
+		  <url>https://download.eclipse.org/releases/kepler/</url>
 		</repository>
 		<repository>
 		  <id>ajdt</id>
 		  <layout>p2</layout>
-		  <url>http://download.eclipse.org/tools/ajdt/43/update</url>
+		  <url>https://download.eclipse.org/tools/ajdt/43/update</url>
 		</repository>
 		<repository>
 		  <id>swtbot</id>
 		  <layout>p2</layout>
-		  <url>http://download.eclipse.org/technology/swtbot/releases/latest/</url>
+		  <url>https://download.eclipse.org/technology/swtbot/releases/latest/</url>
 		</repository>
 		<repository>
 		  <id>groovy</id>
 		  <layout>p2</layout>
-		  <url>http://dist.springsource.org/snapshot/GRECLIPSE/e4.3-j8/</url>
+		  <url>https://dist.springsource.org/snapshot/GRECLIPSE/e4.3-j8/</url>
 		</repository>
 		<repository>
 		  <id>eclipse-integration-commons</id>
 		  <layout>p2</layout>
-		  <url>http://dist.springsource.com/${dist.type}/TOOLS/eclipse-integration-commons/${dist.eclipse-integration-commons-version}/e3.7/</url>
+		  <url>https://dist.springsource.com/${dist.type}/TOOLS/eclipse-integration-commons/${dist.eclipse-integration-commons-version}/e3.7/</url>
 		</repository>
 	  </repositories>
     </profile>
@@ -330,40 +330,40 @@
 		<repository>
 		  <id>platform</id>
 		  <layout>p2</layout>
-		  <url>http://download.eclipse.org/eclipse/updates/4.4milestones</url>
+		  <url>https://download.eclipse.org/eclipse/updates/4.4milestones</url>
 		</repository>
 <!--   Should be using this, but it doesn't exist yet...
        <repository>
 		  <id>luna</id>
 		  <layout>p2</layout>
-		  <url>http://download.eclipse.org/releases/kepler/</url>
+		  <url>https://download.eclipse.org/releases/kepler/</url>
 		</repository> 
 		So we use this instead: -->
 		<repository>
 		  <id>kepler</id>
 		  <layout>p2</layout>
-		  <url>http://download.eclipse.org/releases/kepler/</url>
+		  <url>https://download.eclipse.org/releases/kepler/</url>
 		</repository>
 		<repository>
 		  <id>ajdt</id>
 		  <layout>p2</layout>
-		  <url>http://download.eclipse.org/tools/ajdt/44/dev/update</url>
-		  <!--  when available should use release: http://download.eclipse.org/tools/ajdt/44/update -->
+		  <url>https://download.eclipse.org/tools/ajdt/44/dev/update</url>
+		  <!--  when available should use release: https://download.eclipse.org/tools/ajdt/44/update -->
 		</repository>
 		<repository>
 		  <id>swtbot</id>
 		  <layout>p2</layout>
-		  <url>http://download.eclipse.org/technology/swtbot/releases/latest/</url>
+		  <url>https://download.eclipse.org/technology/swtbot/releases/latest/</url>
 		</repository>
 		<repository>
 		  <id>groovy</id>
 		  <layout>p2</layout>
-		  <url>http://dist.springsource.org/snapshot/GRECLIPSE/e4.4/</url>
+		  <url>https://dist.springsource.org/snapshot/GRECLIPSE/e4.4/</url>
 		</repository>
 		<repository>
 		  <id>eclipse-integration-commons</id>
 		  <layout>p2</layout>
-		  <url>http://dist.springsource.com/${dist.type}/TOOLS/eclipse-integration-commons/${dist.eclipse-integration-commons-version}/e4.4/</url>
+		  <url>https://dist.springsource.com/${dist.type}/TOOLS/eclipse-integration-commons/${dist.eclipse-integration-commons-version}/e4.4/</url>
 		</repository>
 	  </repositories>
     </profile>
@@ -410,7 +410,7 @@
       <activation>
         <property>
           <name>java.vendor.url</name>
-          <value>http://www.apple.com/</value>
+          <value>https://www.apple.com/</value>
         </property>
       </activation>
       <properties>
@@ -431,26 +431,26 @@
  	<repository>
 	  <id>orbit</id>
 	  <layout>p2</layout>
-	  <url>http://download.eclipse.org/tools/orbit/downloads/drops/R20120526062928/repository/</url>
+	  <url>https://download.eclipse.org/tools/orbit/downloads/drops/R20120526062928/repository/</url>
 	</repository>
 
     <repository>
       <id>m2e</id>
 	  <layout>p2</layout>
-      <url>http://download.eclipse.org/technology/m2e/releases/1.4/1.4.0.20130601-0317</url>
+      <url>https://download.eclipse.org/technology/m2e/releases/1.4/1.4.0.20130601-0317</url>
     </repository>
 
 	<repository>
 	  <id>mylyn</id>
 	  <layout>p2</layout>
-	  <url>http://download.eclipse.org/mylyn/releases/3.7</url>
+	  <url>https://download.eclipse.org/mylyn/releases/3.7</url>
 	</repository>
 	
     <!-- required for Maven and Ant AWS dependency -->
     <repository>
       <id>springsource-maven-release</id>
       <name>SpringSource Maven Release Repository</name>
-      <url>http://repository.springsource.com/maven/bundles/release</url>
+      <url>https://repository.springsource.com/maven/bundles/release</url>
     </repository>
     <!-- required for commons-cli dependency in c.s.sts.grails.core -->
     <repository>
@@ -459,7 +459,7 @@
     </repository>
     <repository>
       <id>maven-mirror</id>
-      <url>http://repo.exist.com/maven2</url>
+      <url>https://repo.exist.com/maven2</url>
     </repository>
   </repositories>
   
@@ -468,12 +468,12 @@
     <pluginRepository>
       <id>spring-maven-release</id>
       <name>Spring Maven Release Repository</name>
-      <url>http://maven.springframework.org/release</url>
+      <url>https://maven.springframework.org/release</url>
     </pluginRepository>
     <pluginRepository>
       <id>springsource-maven-release</id>
       <name>SpringSource Maven Release Repository</name>
-      <url>http://repository.springsource.com/maven/bundles/release</url>
+      <url>https://repository.springsource.com/maven/bundles/release</url>
     </pluginRepository>
   </pluginRepositories>
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://www.myorganization.org (200) migrated to:  
  http://www.myorganization.org ([https](https://www.myorganization.org) result SSLException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://git.springsource.com/sts/grails-ide (UnknownHostException) migrated to:  
  https://git.springsource.com/sts/grails-ide ([https](https://git.springsource.com/sts/grails-ide) result UnknownHostException).
* http://repo.exist.com/maven2 (UnknownHostException) migrated to:  
  https://repo.exist.com/maven2 ([https](https://repo.exist.com/maven2) result UnknownHostException).
* http://dist.springsource.com/ (403) migrated to:  
  https://dist.springsource.com/ ([https](https://dist.springsource.com/) result 403).
* http://dist.springsource.com/release/TOOLS/patches/bug367669 (403) migrated to:  
  https://dist.springsource.com/release/TOOLS/patches/bug367669 ([https](https://dist.springsource.com/release/TOOLS/patches/bug367669) result 403).
* http://dist.springsource.com/snapshot/TOOLS/grails-ide/nightly (403) migrated to:  
  https://dist.springsource.com/snapshot/TOOLS/grails-ide/nightly ([https](https://dist.springsource.com/snapshot/TOOLS/grails-ide/nightly) result 403).
* http://download.eclipse.org/eclipse/updates/4.4milestones (404) migrated to:  
  https://download.eclipse.org/eclipse/updates/4.4milestones ([https](https://download.eclipse.org/eclipse/updates/4.4milestones) result 404).
* http://repository.springsource.com/maven/bundles/release (404) migrated to:  
  https://repository.springsource.com/maven/bundles/release ([https](https://repository.springsource.com/maven/bundles/release) result 404).

## Fixed Success 
These URLs were fixed successfully.

* http://dist.springsource.com/snapshot/TOOLS/eclipse-integration-commons/nightly/ migrated to:  
  https://dist.springsource.com/snapshot/TOOLS/eclipse-integration-commons/nightly/ ([https](https://dist.springsource.com/snapshot/TOOLS/eclipse-integration-commons/nightly/) result 200).
* http://dist.springsource.org/snapshot/GRECLIPSE/e3.7/ migrated to:  
  https://dist.springsource.org/snapshot/GRECLIPSE/e3.7/ ([https](https://dist.springsource.org/snapshot/GRECLIPSE/e3.7/) result 200).
* http://dist.springsource.org/snapshot/GRECLIPSE/e4.2/ migrated to:  
  https://dist.springsource.org/snapshot/GRECLIPSE/e4.2/ ([https](https://dist.springsource.org/snapshot/GRECLIPSE/e4.2/) result 200).
* http://dist.springsource.org/snapshot/GRECLIPSE/e4.3-j8/ migrated to:  
  https://dist.springsource.org/snapshot/GRECLIPSE/e4.3-j8/ ([https](https://dist.springsource.org/snapshot/GRECLIPSE/e4.3-j8/) result 200).
* http://dist.springsource.org/snapshot/GRECLIPSE/e4.3/ migrated to:  
  https://dist.springsource.org/snapshot/GRECLIPSE/e4.3/ ([https](https://dist.springsource.org/snapshot/GRECLIPSE/e4.3/) result 200).
* http://dist.springsource.org/snapshot/GRECLIPSE/e4.4/ migrated to:  
  https://dist.springsource.org/snapshot/GRECLIPSE/e4.4/ ([https](https://dist.springsource.org/snapshot/GRECLIPSE/e4.4/) result 200).
* http://download.eclipse.org/eclipse/updates/3.7/ migrated to:  
  https://download.eclipse.org/eclipse/updates/3.7/ ([https](https://download.eclipse.org/eclipse/updates/3.7/) result 200).
* http://download.eclipse.org/eclipse/updates/4.2/ migrated to:  
  https://download.eclipse.org/eclipse/updates/4.2/ ([https](https://download.eclipse.org/eclipse/updates/4.2/) result 200).
* http://download.eclipse.org/eclipse/updates/4.3/ migrated to:  
  https://download.eclipse.org/eclipse/updates/4.3/ ([https](https://download.eclipse.org/eclipse/updates/4.3/) result 200).
* http://download.eclipse.org/releases/indigo/ migrated to:  
  https://download.eclipse.org/releases/indigo/ ([https](https://download.eclipse.org/releases/indigo/) result 200).
* http://download.eclipse.org/releases/juno/ migrated to:  
  https://download.eclipse.org/releases/juno/ ([https](https://download.eclipse.org/releases/juno/) result 200).
* http://download.eclipse.org/releases/kepler/ migrated to:  
  https://download.eclipse.org/releases/kepler/ ([https](https://download.eclipse.org/releases/kepler/) result 200).
* http://download.eclipse.org/technology/swtbot/helios/dev-build/update-site/ migrated to:  
  https://download.eclipse.org/technology/swtbot/helios/dev-build/update-site/ ([https](https://download.eclipse.org/technology/swtbot/helios/dev-build/update-site/) result 200).
* http://download.eclipse.org/technology/swtbot/releases/latest/ migrated to:  
  https://download.eclipse.org/technology/swtbot/releases/latest/ ([https](https://download.eclipse.org/technology/swtbot/releases/latest/) result 200).
* http://download.eclipse.org/tools/ajdt/37/milestone/ migrated to:  
  https://download.eclipse.org/tools/ajdt/37/milestone/ ([https](https://download.eclipse.org/tools/ajdt/37/milestone/) result 200).
* http://download.eclipse.org/tools/ajdt/42/milestone/ migrated to:  
  https://download.eclipse.org/tools/ajdt/42/milestone/ ([https](https://download.eclipse.org/tools/ajdt/42/milestone/) result 200).
* http://download.eclipse.org/tools/ajdt/43/milestone/ migrated to:  
  https://download.eclipse.org/tools/ajdt/43/milestone/ ([https](https://download.eclipse.org/tools/ajdt/43/milestone/) result 200).
* http://download.eclipse.org/tools/orbit/downloads/drops/R20120526062928/repository/ migrated to:  
  https://download.eclipse.org/tools/orbit/downloads/drops/R20120526062928/repository/ ([https](https://download.eclipse.org/tools/orbit/downloads/drops/R20120526062928/repository/) result 200).
* http://spring.io migrated to:  
  https://spring.io ([https](https://spring.io) result 200).
* http://spring.io/tools migrated to:  
  https://spring.io/tools ([https](https://spring.io/tools) result 200).
* http://www.apple.com/ migrated to:  
  https://www.apple.com/ ([https](https://www.apple.com/) result 200).
* http://download.eclipse.org/eclipse/updates/3.7/R-3.7-201106131736 migrated to:  
  https://download.eclipse.org/eclipse/updates/3.7/R-3.7-201106131736 ([https](https://download.eclipse.org/eclipse/updates/3.7/R-3.7-201106131736) result 301).
* http://download.eclipse.org/mylyn/releases/3.7 migrated to:  
  https://download.eclipse.org/mylyn/releases/3.7 ([https](https://download.eclipse.org/mylyn/releases/3.7) result 301).
* http://download.eclipse.org/technology/m2e/releases/1.4/1.4.0.20130601-0317 migrated to:  
  https://download.eclipse.org/technology/m2e/releases/1.4/1.4.0.20130601-0317 ([https](https://download.eclipse.org/technology/m2e/releases/1.4/1.4.0.20130601-0317) result 301).
* http://download.eclipse.org/tools/ajdt/43/update migrated to:  
  https://download.eclipse.org/tools/ajdt/43/update ([https](https://download.eclipse.org/tools/ajdt/43/update) result 301).
* http://download.eclipse.org/tools/ajdt/44/dev/update migrated to:  
  https://download.eclipse.org/tools/ajdt/44/dev/update ([https](https://download.eclipse.org/tools/ajdt/44/dev/update) result 301).
* http://download.eclipse.org/tools/ajdt/44/update migrated to:  
  https://download.eclipse.org/tools/ajdt/44/update ([https](https://download.eclipse.org/tools/ajdt/44/update) result 301).
* http://maven.springframework.org/release migrated to:  
  https://maven.springframework.org/release ([https](https://maven.springframework.org/release) result 302).
* http://repo.grails.org/grails/core migrated to:  
  https://repo.grails.org/grails/core ([https](https://repo.grails.org/grails/core) result 302).
* http://repo.grails.org/grails/plugins migrated to:  
  https://repo.grails.org/grails/plugins ([https](https://repo.grails.org/grails/plugins) result 302).
* http://repo.spring.io/plugins-snapshot-local migrated to:  
  https://repo.spring.io/plugins-snapshot-local ([https](https://repo.spring.io/plugins-snapshot-local) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance