### PR TITLE
URL Cleanup

### DIFF
--- a/open_source_licenses.txt
+++ b/open_source_licenses.txt
@@ -118,7 +118,7 @@ Copyright (c) 1997-2005 The Apache Software Foundation. All rights reserved.
 Your use of the Commons IO code is subject to the terms and conditions of the Apache Software License 2.0. A copy of the license is contained in the file 
 LICENSE.txt
  and is also available at 
-http://www.apache.org/licenses/LICENSE-2.0.html
+https://www.apache.org/licenses/LICENSE-2.0.html
 .
 The Apache attribution 
 NOTICE.txt
@@ -602,7 +602,7 @@ to a jury trial in any resulting litigation.
 Apache License 
 
 Version 2.0, January 2004 
-http://www.apache.org/licenses/ 
+https://www.apache.org/licenses/ 
 
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
 

--- a/org.grails.ide.eclipse.core/src/org/grails/ide/eclipse/core/util/CommandLineUtil.java
+++ b/org.grails.ide.eclipse.core/src/org/grails/ide/eclipse/core/util/CommandLineUtil.java
@@ -14,7 +14,7 @@ import org.springsource.ide.eclipse.commons.frameworks.core.ExceptionUtil;
  *  (the "License"); you may not use this file except in compliance with
  *  the License.  You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.grails.ide.eclipse.resources/dsl-support/dsld/grails.dsld
+++ b/org.grails.ide.eclipse.resources/dsl-support/dsld/grails.dsld
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.grails.ide.eclipse.runtime22/src/org/grails/ide/eclipse/runtime/GrailsEclipseConsole.java
+++ b/org.grails.ide.eclipse.runtime22/src/org/grails/ide/eclipse/runtime/GrailsEclipseConsole.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.grails.ide.eclipse.test/src/org/grails/ide/eclipse/test/MockGrailsTestProjectUtils.java
+++ b/org.grails.ide.eclipse.test/src/org/grails/ide/eclipse/test/MockGrailsTestProjectUtils.java
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.grails.ide.eclipse.tests/feature.properties
+++ b/org.grails.ide.eclipse.tests/feature.properties
@@ -144,7 +144,7 @@ Copyright (c) 1997-2005 The Apache Software Foundation. All rights reserved.\n\
 Your use of the Commons IO code is subject to the terms and conditions of the Apache Software License 2.0. A copy of the license is contained in the file \n\
 LICENSE.txt\n\
  and is also available at \n\
-http://www.apache.org/licenses/LICENSE-2.0.html\n\
+https://www.apache.org/licenses/LICENSE-2.0.html\n\
 .\n\
 The Apache attribution \n\
 NOTICE.txt\n\
@@ -628,7 +628,7 @@ to a jury trial in any resulting litigation.\n\
 Apache License \n\
 \n\
 Version 2.0, January 2004 \n\
-http://www.apache.org/licenses/ \n\
+https://www.apache.org/licenses/ \n\
 \n\
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION \n\
 \n\

--- a/org.grails.ide.eclipse.tests/open_source_licenses.txt
+++ b/org.grails.ide.eclipse.tests/open_source_licenses.txt
@@ -118,7 +118,7 @@ Copyright (c) 1997-2005 The Apache Software Foundation. All rights reserved.
 Your use of the Commons IO code is subject to the terms and conditions of the Apache Software License 2.0. A copy of the license is contained in the file 
 LICENSE.txt
  and is also available at 
-http://www.apache.org/licenses/LICENSE-2.0.html
+https://www.apache.org/licenses/LICENSE-2.0.html
 .
 The Apache attribution 
 NOTICE.txt
@@ -602,7 +602,7 @@ to a jury trial in any resulting litigation.
 Apache License 
 
 Version 2.0, January 2004 
-http://www.apache.org/licenses/ 
+https://www.apache.org/licenses/ 
 
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
 

--- a/org.grails.ide.eclipse/feature.properties
+++ b/org.grails.ide.eclipse/feature.properties
@@ -144,7 +144,7 @@ Copyright (c) 1997-2005 The Apache Software Foundation. All rights reserved.\n\
 Your use of the Commons IO code is subject to the terms and conditions of the Apache Software License 2.0. A copy of the license is contained in the file \n\
 LICENSE.txt\n\
  and is also available at \n\
-http://www.apache.org/licenses/LICENSE-2.0.html\n\
+https://www.apache.org/licenses/LICENSE-2.0.html\n\
 .\n\
 The Apache attribution \n\
 NOTICE.txt\n\
@@ -628,7 +628,7 @@ to a jury trial in any resulting litigation.\n\
 Apache License \n\
 \n\
 Version 2.0, January 2004 \n\
-http://www.apache.org/licenses/ \n\
+https://www.apache.org/licenses/ \n\
 \n\
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION \n\
 \n\

--- a/org.grails.ide.eclipse/open_source_licenses.txt
+++ b/org.grails.ide.eclipse/open_source_licenses.txt
@@ -118,7 +118,7 @@ Copyright (c) 1997-2005 The Apache Software Foundation. All rights reserved.
 Your use of the Commons IO code is subject to the terms and conditions of the Apache Software License 2.0. A copy of the license is contained in the file 
 LICENSE.txt
  and is also available at 
-http://www.apache.org/licenses/LICENSE-2.0.html
+https://www.apache.org/licenses/LICENSE-2.0.html
 .
 The Apache attribution 
 NOTICE.txt
@@ -602,7 +602,7 @@ to a jury trial in any resulting litigation.
 Apache License 
 
 Version 2.0, January 2004 
-http://www.apache.org/licenses/ 
+https://www.apache.org/licenses/ 
 
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION 
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 5 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 4 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0.html with 5 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.html ([https](https://www.apache.org/licenses/LICENSE-2.0.html) result 200).